### PR TITLE
feat: switch base OS to openSUSE MicroOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Full one-shot deploy (same as tofu apply — null_resource runs Ansible automatically)
 deploy:
-	cd tofu && tofu apply
+	TF_VAR_k3s_token=$$(openssl rand -hex 32) tofu -chdir=tofu apply
 
 # Re-run only Ansible site.yml (fetch kubeconfig)
 cluster:

--- a/README.md
+++ b/README.md
@@ -128,22 +128,18 @@ cd tofu
 echo 'ssh_public_key = "ssh-ed25519 AAAA... your-comment"' > terraform.tfvars
 ```
 
-Generate a cluster token and export it so OpenTofu can read it:
-
-```bash
-export TF_VAR_k3s_token=$(openssl rand -hex 32)
-```
-
-Then initialise and apply:
+Generate a cluster token and export it so OpenTofu can read it, then initialise and apply:
 
 ```bash
 tofu init
-tofu apply
+make deploy
 ```
+
+`make deploy` generates a fresh token automatically and passes it to tofu inline.
 
 This single command does everything:
 
-1. Downloads the Debian 13 base image and creates the libvirt network
+1. Downloads the openSUSE MicroOS base image and creates the libvirt network
 2. Provisions all 6 VMs -- cloud-init installs k3s, configures kube-vip, and joins nodes
 3. Runs `ansible-playbook site.yml` -- waits for the cluster to be Ready and fetches kubeconfig
 4. Runs `ansible-playbook addons.yml` -- deploys cert-manager, MetalLB, Traefik, and ArgoCD
@@ -192,11 +188,7 @@ Open `https://argocd.local` in your browser. You will get a certificate warning 
 
 ### Cluster token
 
-The token is passed to OpenTofu via the `TF_VAR_k3s_token` environment variable and baked into cloud-init at provisioning time. It is never stored in version control.
-
-```bash
-export TF_VAR_k3s_token=$(openssl rand -hex 32)
-```
+`make deploy` generates a fresh token automatically via `openssl rand -hex 32` and passes it inline to tofu. The token is never stored in version control or on disk.
 
 ### Versions
 
@@ -223,7 +215,6 @@ Node counts, IPs, CPU, and memory are all defined in `tofu/variables.tf`. Overri
 ### Tear down and redeploy
 
 ```bash
-export TF_VAR_k3s_token=$(openssl rand -hex 32)
 make destroy
 make deploy
 ```
@@ -243,7 +234,7 @@ virsh -c qemu:///system start k3s-master-1
 ### SSH into a node
 
 ```bash
-ssh -i ~/.ssh/id_ed25519 debian@192.168.100.11
+ssh -i ~/.ssh/id_ed25519 opensuse@192.168.100.11
 ```
 
 ### Issuing certificates for other services
@@ -257,5 +248,6 @@ annotations:
 
 ## Notes
 
-- The cluster token is passed via `TF_VAR_k3s_token` and baked into cloud-init. It is never written to disk on the host or committed to version control.
+- The cluster token is generated fresh on each `make deploy` and passed inline to tofu. It is never written to disk on the host or committed to version control.
+- Nodes run openSUSE MicroOS (immutable root filesystem). OS-level updates are handled via `transactional-update`; k3s upgrades are managed by system-upgrade-controller.
 - The self-signed CA certificate is valid for 10 years. Import `k3s-ca-secret` from the `cert-manager` namespace into your system trust store to avoid browser warnings.

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -1,6 +1,6 @@
 all:
   vars:
-    ansible_user: debian
+    ansible_user: opensuse
     ansible_ssh_private_key_file: ~/.ssh/id_ed25519
     ansible_python_interpreter: /usr/bin/python3
 

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -20,13 +20,14 @@
 
     - name: Wait for init master node to be Ready
       command: >
-        k3s kubectl get node {{ inventory_hostname }}
-        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+        /usr/local/bin/k3s kubectl wait node/{{ inventory_hostname }}
+        --for=condition=Ready --timeout=10s
       register: node_ready
-      until: node_ready.stdout == "True"
+      until: node_ready.rc == 0
       retries: 30
       delay: 10
       changed_when: false
+      failed_when: false
       become: true
 
     - name: Fetch kubeconfig

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -49,7 +49,7 @@ resource "libvirt_network" "k3s_net" {
 # ── Base image (downloaded once, shared as backing file) ──────────────────────
 
 resource "libvirt_volume" "base_image" {
-  name = "debian-13-k3s-base.qcow2"
+  name = "microos-k3s-base.qcow2"
   pool = var.storage_pool
 
   create = {

--- a/tofu/templates/network_config.yaml.tpl
+++ b/tofu/templates/network_config.yaml.tpl
@@ -1,14 +1,12 @@
 version: 2
 ethernets:
-  id0:
-    match:
-      driver: virtio_net
+  enp0s3:
     dhcp4: false
     dhcp6: false
     addresses:
       - ${ip_address}/24
     routes:
-      - to: default
+      - to: 0.0.0.0/0
         via: ${gateway}
     nameservers:
       addresses:

--- a/tofu/templates/user_data_init_master.yaml.tpl
+++ b/tofu/templates/user_data_init_master.yaml.tpl
@@ -4,24 +4,20 @@ fqdn: ${hostname}.local
 manage_etc_hosts: true
 
 users:
-  - name: debian
-    gecos: Debian User
+  - name: opensuse
+    gecos: openSUSE User
     sudo: ALL=(ALL) NOPASSWD:ALL
     shell: /bin/bash
     lock_passwd: true
     ssh_authorized_keys:
       - ${ssh_public_key}
 
-packages:
-  - curl
-  - ca-certificates
-
-package_update: true
-package_upgrade: true
-
-# bootcmd runs on every boot before write_files/packages/runcmd — ensures
+# bootcmd runs on every boot before write_files/runcmd — ensures
 # modules are loaded before any sysctl settings referencing them are applied
 bootcmd:
+  - systemctl mask health-checker.service || true
+  - systemctl daemon-reload
+  - systemctl start --no-block cloud-final.service || true
   - modprobe br_netfilter
   - modprobe overlay
   - mkdir -p /var/lib/rancher/k3s/server/manifests
@@ -85,6 +81,8 @@ write_files:
       net.ipv6.conf.all.forwarding = 1
 
 runcmd:
+  - sed -i 's/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=0/' /etc/default/grub
+  - grub2-mkconfig -o /boot/grub2/grub.cfg
   - sysctl --system
   - swapoff -a
   - sed -i '/\sswap\s/d' /etc/fstab
@@ -160,3 +158,4 @@ runcmd:
     KVEOF
   - curl -sfL "https://github.com/rancher/system-upgrade-controller/releases/download/${suc_version}/system-upgrade-controller.yaml" -o /var/lib/rancher/k3s/server/manifests/system-upgrade-controller.yaml
   - curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${k3s_version}" INSTALL_K3S_EXEC="--cluster-init --write-kubeconfig-mode=0644" sh -
+  - systemctl start k3s || true

--- a/tofu/templates/user_data_join_master.yaml.tpl
+++ b/tofu/templates/user_data_join_master.yaml.tpl
@@ -4,22 +4,18 @@ fqdn: ${hostname}.local
 manage_etc_hosts: true
 
 users:
-  - name: debian
-    gecos: Debian User
+  - name: opensuse
+    gecos: openSUSE User
     sudo: ALL=(ALL) NOPASSWD:ALL
     shell: /bin/bash
     lock_passwd: true
     ssh_authorized_keys:
       - ${ssh_public_key}
 
-packages:
-  - curl
-  - ca-certificates
-
-package_update: true
-package_upgrade: true
-
 bootcmd:
+  - systemctl mask health-checker.service || true
+  - systemctl daemon-reload
+  - systemctl start --no-block cloud-final.service || true
   - modprobe br_netfilter
   - modprobe overlay
 
@@ -41,6 +37,8 @@ write_files:
       net.ipv6.conf.all.forwarding = 1
 
 runcmd:
+  - sed -i 's/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=0/' /etc/default/grub
+  - grub2-mkconfig -o /boot/grub2/grub.cfg
   - sysctl --system
   - swapoff -a
   - sed -i '/\sswap\s/d' /etc/fstab
@@ -121,3 +119,4 @@ runcmd:
       ATTEMPTS=$((ATTEMPTS+1)); [ $ATTEMPTS -ge 60 ] && exit 1; sleep 5
     done
   - curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${k3s_version}" INSTALL_K3S_EXEC="server --write-kubeconfig-mode=0644" sh -
+  - systemctl start k3s || true

--- a/tofu/templates/user_data_worker.yaml.tpl
+++ b/tofu/templates/user_data_worker.yaml.tpl
@@ -4,22 +4,18 @@ fqdn: ${hostname}.local
 manage_etc_hosts: true
 
 users:
-  - name: debian
-    gecos: Debian User
+  - name: opensuse
+    gecos: openSUSE User
     sudo: ALL=(ALL) NOPASSWD:ALL
     shell: /bin/bash
     lock_passwd: true
     ssh_authorized_keys:
       - ${ssh_public_key}
 
-packages:
-  - curl
-  - ca-certificates
-
-package_update: true
-package_upgrade: true
-
 bootcmd:
+  - systemctl mask health-checker.service || true
+  - systemctl daemon-reload
+  - systemctl start --no-block cloud-final.service || true
   - modprobe br_netfilter
   - modprobe overlay
 
@@ -37,6 +33,8 @@ write_files:
       net.ipv6.conf.all.forwarding = 1
 
 runcmd:
+  - sed -i 's/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=0/' /etc/default/grub
+  - grub2-mkconfig -o /boot/grub2/grub.cfg
   - sysctl --system
   - swapoff -a
   - sed -i '/\sswap\s/d' /etc/fstab

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -5,9 +5,9 @@ variable "libvirt_uri" {
 }
 
 variable "base_image_url" {
-  description = "URL to Debian 12 (Bookworm) genericcloud qcow2 image"
+  description = "URL to openSUSE MicroOS OpenStack Cloud qcow2 image"
   type        = string
-  default     = "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2"
+  default     = "https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
 }
 
 variable "storage_pool" {


### PR DESCRIPTION
## Summary

- Replaces Debian 13 base image with openSUSE MicroOS (OpenStack Cloud variant)
- Updates cloud-init templates for MicroOS: opensuse user, no package management, correct network config, health-checker ordering fix
- Explicit k3s service start after install to work around MicroOS cloud-final boot issue
- Ansible inventory and site.yml updated for MicroOS conventions
- Simplified `make deploy` with inline token generation

## MicroOS-specific fixes discovered during testing

- Network config: `match.driver: virtio_net` not supported by MicroOS cloud-init renderer; replaced with explicit `enp0s3` interface name and `0.0.0.0/0` default route (MicroOS rejects `default` keyword)
- `health-checker.service` creates a systemd ordering cycle that kills `cloud-final.service` on first boot; masked in `bootcmd` with `daemon-reload` + `--no-block` re-queue
- k3s install script does not start the service on MicroOS; added explicit `systemctl start` after install
- Ansible node readiness check used jsonpath filter syntax unsupported by k3s kubectl; replaced with `kubectl wait`; full binary path required as sudo strips `/usr/local/bin` from PATH

Closes #4