### PR TITLE
fix: surface silent failures in addon waits, harden cloud-init and tofu vars

### DIFF
--- a/ansible/roles/addons/tasks/argocd.yml
+++ b/ansible/roles/addons/tasks/argocd.yml
@@ -19,7 +19,6 @@
     argocd_deploy.resources[0].spec.replicas
   retries: 30
   delay: 10
-  failed_when: false
   delegate_to: localhost
   become: false
 
@@ -46,7 +45,6 @@
     | list | length > 0
   retries: 12
   delay: 10
-  failed_when: false
   delegate_to: localhost
   become: false
 

--- a/ansible/roles/addons/tasks/cert_manager.yml
+++ b/ansible/roles/addons/tasks/cert_manager.yml
@@ -19,7 +19,6 @@
     cm_deploy.resources[0].spec.replicas
   retries: 30
   delay: 10
-  failed_when: false
   delegate_to: localhost
   become: false
 
@@ -36,7 +35,6 @@
     cm_webhook.resources[0].spec.replicas
   retries: 20
   delay: 10
-  failed_when: false
   delegate_to: localhost
   become: false
 
@@ -49,7 +47,6 @@
   until: cm_webhook_config.resources is defined and cm_webhook_config.resources | length > 0
   retries: 20
   delay: 5
-  failed_when: false
   delegate_to: localhost
   become: false
 
@@ -83,7 +80,6 @@
     | list | length > 0
   retries: 12
   delay: 10
-  failed_when: false
   delegate_to: localhost
   become: false
 

--- a/ansible/roles/addons/tasks/metallb.yml
+++ b/ansible/roles/addons/tasks/metallb.yml
@@ -19,7 +19,6 @@
     metallb_deploy.resources[0].spec.replicas
   retries: 30
   delay: 10
-  failed_when: false
   delegate_to: localhost
   become: false
 
@@ -32,7 +31,6 @@
   until: metallb_webhook_config.resources is defined and metallb_webhook_config.resources | length > 0
   retries: 20
   delay: 5
-  failed_when: false
   delegate_to: localhost
   become: false
 

--- a/ansible/roles/addons/tasks/traefik.yml
+++ b/ansible/roles/addons/tasks/traefik.yml
@@ -19,6 +19,5 @@
     traefik_svc.resources[0].status.loadBalancer.ingress[0].ip == traefik_ip
   retries: 30
   delay: 10
-  failed_when: false
   delegate_to: localhost
   become: false

--- a/tofu/templates/user_data_init_master.yaml.tpl
+++ b/tofu/templates/user_data_init_master.yaml.tpl
@@ -81,7 +81,7 @@ write_files:
       net.ipv6.conf.all.forwarding = 1
 
 runcmd:
-  - sed -i 's/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=0/' /etc/default/grub
+  - '[ -f /etc/default/grub ] && sed -i ''s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=0/'' /etc/default/grub || true'
   - grub2-mkconfig -o /boot/grub2/grub.cfg
   - sysctl --system
   - swapoff -a
@@ -107,6 +107,7 @@ runcmd:
   - mkdir -p /var/lib/rancher/k3s/agent/pod-manifests
   - |
     IFACE=$(ip route get ${kube_vip_ip} | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' | head -1)
+    [ -z "$IFACE" ] && { echo "ERROR: could not determine network interface for kube-vip VIP ${kube_vip_ip}"; exit 1; }
     cat > /var/lib/rancher/k3s/agent/pod-manifests/kube-vip.yaml << KVEOF
     apiVersion: v1
     kind: Pod

--- a/tofu/templates/user_data_join_master.yaml.tpl
+++ b/tofu/templates/user_data_join_master.yaml.tpl
@@ -37,7 +37,7 @@ write_files:
       net.ipv6.conf.all.forwarding = 1
 
 runcmd:
-  - sed -i 's/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=0/' /etc/default/grub
+  - '[ -f /etc/default/grub ] && sed -i ''s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=0/'' /etc/default/grub || true'
   - grub2-mkconfig -o /boot/grub2/grub.cfg
   - sysctl --system
   - swapoff -a
@@ -63,6 +63,7 @@ runcmd:
   - mkdir -p /var/lib/rancher/k3s/agent/pod-manifests
   - |
     IFACE=$(ip route get ${kube_vip_ip} | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' | head -1)
+    [ -z "$IFACE" ] && { echo "ERROR: could not determine network interface for kube-vip VIP ${kube_vip_ip}"; exit 1; }
     cat > /var/lib/rancher/k3s/agent/pod-manifests/kube-vip.yaml << KVEOF
     apiVersion: v1
     kind: Pod

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -26,12 +26,22 @@ variable "network_cidr" {
   description = "CIDR for the k3s NAT network"
   type        = string
   default     = "192.168.100.0/24"
+
+  validation {
+    condition     = can(cidrhost(var.network_cidr, 0))
+    error_message = "network_cidr must be a valid CIDR block (e.g., 192.168.100.0/24)."
+  }
 }
 
 variable "gateway" {
   description = "Gateway IP for the k3s network"
   type        = string
   default     = "192.168.100.1"
+
+  validation {
+    condition     = can(regex("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$", var.gateway))
+    error_message = "gateway must be a valid IPv4 address."
+  }
 }
 
 variable "dns_servers" {
@@ -62,6 +72,11 @@ variable "kube_vip_ip" {
   description = "ARP virtual IP for the k3s API server (kube-vip)"
   type        = string
   default     = "192.168.100.100"
+
+  validation {
+    condition     = can(regex("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$", var.kube_vip_ip))
+    error_message = "kube_vip_ip must be a valid IPv4 address."
+  }
 }
 
 variable "kube_vip_version" {


### PR DESCRIPTION
## Summary

- Remove `failed_when: false` from all addon wait loops (cert-manager, metallb, argocd, traefik) — timed-out deploys now fail visibly at the right task instead of silently continuing
- Guard grub `sed` against missing `/etc/default/grub` on MicroOS in both master cloud-init templates
- Fail fast with a clear error if kube-vip IFACE lookup returns empty in both master cloud-init templates
- Add `validation` blocks to `network_cidr`, `gateway`, and `kube_vip_ip` in `variables.tf`

## Test plan

- [x] Full cluster deploy completed successfully on fix branch
- [x] HA verified: stopped k3s on master-1, etcd leader election confirmed on master-2/3, VIP failed over correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)