### PR TITLE
chore: add ansible-lint and yamllint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+profile: basic
+skip_list:
+  - var-naming[no-role-prefix]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install linters
         run: pip install ansible-lint yamllint
 
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
+
       - name: Run yamllint
         run: yamllint ansible/
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+---
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install linters
+        run: pip install ansible-lint yamllint
+
+      - name: Run yamllint
+        run: yamllint ansible/
+
+      - name: Run ansible-lint
+        run: ansible-lint ansible/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,15 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 160
+  document-start:
+    present: true
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,3 +1,4 @@
+---
 # kube-vip VIP — used to rewrite the fetched kubeconfig server address
 kube_vip_ip: "192.168.100.100"
 

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -1,3 +1,4 @@
+---
 all:
   vars:
     ansible_user: opensuse

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,3 +1,4 @@
+---
 collections:
   - name: community.general
     version: ">=9.0.0"

--- a/ansible/roles/addons/defaults/main.yml
+++ b/ansible/roles/addons/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 cert_manager_version: "v1.20.0"
 argocd_chart_version: "9.4.17"
 metallb_chart_version: "0.15.3"

--- a/ansible/roles/addons/tasks/main.yml
+++ b/ansible/roles/addons/tasks/main.yml
@@ -42,7 +42,14 @@
   become: false
   loop: "{{ groups['k3s_workers'] }}"
 
-- import_tasks: cert_manager.yml
-- import_tasks: metallb.yml
-- import_tasks: traefik.yml
-- import_tasks: argocd.yml
+- name: Import cert-manager tasks
+  ansible.builtin.import_tasks: cert_manager.yml
+
+- name: Import metallb tasks
+  ansible.builtin.import_tasks: metallb.yml
+
+- name: Import traefik tasks
+  ansible.builtin.import_tasks: traefik.yml
+
+- name: Import argocd tasks
+  ansible.builtin.import_tasks: argocd.yml


### PR DESCRIPTION
## Summary

- Add `.yamllint.yml` with line-length relaxed to 160 (needed for long `until` blocks)
- Add `.ansible-lint` at basic profile, skipping `var-naming[no-role-prefix]`
- Add `.github/workflows/lint.yml` to run both linters on PRs and pushes to main
- Fix existing violations: missing `---` doc starts, bare `import_tasks` without FQCN or task names

After this PR merges and the `lint` job runs once, enable branch protection on `main` under Settings -> Branches -> Require status checks -> select `lint`.

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)