### PR TITLE
ci: add markdown linting and MicroOS SUC upgrade plans

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,20 @@ jobs:
               - 'ansible/**'
             tofu:
               - 'tofu/**'
+            markdown:
+              - '**/*.md'
+
+  markdown-lint:
+    needs: changes
+    if: needs.changes.outputs.markdown == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "**/*.md"
 
   ansible-lint:
     needs: changes

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,6 @@
+---
+default: true
+# Line length is impractical to enforce in READMEs with URLs and prose
+MD013: false
+# Table pipe alignment style is a renderer concern, not a correctness issue
+MD060: false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A local k3s cluster running on KVM/libvirt VMs, provisioned with OpenTofu and co
 
 ## Architecture
 
-```
+```text
                         Host Machine (KVM/libvirt)
                         NAT Network: 192.168.100.0/24
 ┌───────────────────────────────────────────────────────────────┐
@@ -236,6 +236,31 @@ virsh -c qemu:///system start k3s-master-1
 ```bash
 ssh -i ~/.ssh/id_ed25519 opensuse@192.168.100.11
 ```
+
+### Upgrades
+
+Two independent upgrade paths are managed by [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller), which is deployed automatically on first boot via cloud-init.
+
+#### k3s (automatic)
+
+Two SUC plans (`server-plan`, `agent-plan`) track the k3s `latest` release channel. Masters are upgraded one at a time; workers wait for all masters to finish.
+
+No manual action required -- SUC will roll out new k3s versions automatically as they are published.
+
+#### MicroOS OS packages (manual trigger)
+
+Two SUC plans (`microos-server`, `microos-agent`) run `transactional-update --continue cleanup dup` on each node and reboot if needed. Workers wait for all masters to finish.
+
+These plans do **not** trigger automatically. Annotate all nodes when you want to roll out OS updates:
+
+```bash
+kubectl annotate node \
+  k3s-master-1 k3s-master-2 k3s-master-3 \
+  k3s-worker-1 k3s-worker-2 k3s-worker-3 \
+  plan.upgrade.cattle.io/microos=microos
+```
+
+SUC will drain each node, run the update, reboot if needed, and uncordon before moving to the next.
 
 ### Issuing certificates for other services
 

--- a/tofu/templates/user_data_init_master.yaml.tpl
+++ b/tofu/templates/user_data_init_master.yaml.tpl
@@ -67,6 +67,70 @@ write_files:
         upgrade:
           image: rancher/k3s-upgrade
         channel: https://update.k3s.io/v1-release/channels/latest
+      ---
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: microos
+        namespace: system-upgrade
+      type: Opaque
+      stringData:
+        upgrade.sh: |
+          #!/bin/sh
+          set -e
+          transactional-update --continue cleanup dup
+          [ -f /run/reboot-needed ] && rebootmgrctl reboot now
+      ---
+      apiVersion: upgrade.cattle.io/v1
+      kind: Plan
+      metadata:
+        name: microos-server
+        namespace: system-upgrade
+      spec:
+        concurrency: 1
+        nodeSelector:
+          matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+        serviceAccountName: system-upgrade
+        secrets:
+          - name: microos
+            path: /host/run/system-upgrade/secrets/microos
+        drain:
+          force: true
+        version: microos
+        upgrade:
+          image: registry.opensuse.org/opensuse/tumbleweed:latest
+          command: ["chroot", "/host"]
+          args: ["sh", "/run/system-upgrade/secrets/microos/upgrade.sh"]
+      ---
+      apiVersion: upgrade.cattle.io/v1
+      kind: Plan
+      metadata:
+        name: microos-agent
+        namespace: system-upgrade
+      spec:
+        concurrency: 2
+        nodeSelector:
+          matchExpressions:
+            - key: node-role.kubernetes.io/worker
+              operator: Exists
+        prepare:
+          image: rancher/k3s-upgrade
+          args:
+            - prepare
+            - microos-server
+        serviceAccountName: system-upgrade
+        secrets:
+          - name: microos
+            path: /host/run/system-upgrade/secrets/microos
+        drain:
+          force: true
+        version: microos
+        upgrade:
+          image: registry.opensuse.org/opensuse/tumbleweed:latest
+          command: ["chroot", "/host"]
+          args: ["sh", "/run/system-upgrade/secrets/microos/upgrade.sh"]
 
   - path: /etc/modules-load.d/k3s.conf
     content: |


### PR DESCRIPTION
## Summary

- Add `markdownlint-cli2` job to GitHub Actions lint workflow with `**/*.md` path filter
- Add `.markdownlint.yml` disabling MD013 (line length) and MD060 (table pipe style)
- Fix MD040: add `text` language specifier to architecture diagram code fence in README
- Add MicroOS OS upgrade plans (`microos-server`, `microos-agent`) and upgrade `Secret` to cloud-init `upgrade-plans.yaml` on the init master
- Document manual MicroOS upgrade trigger in README Day 2 operations section

## Test plan

- [ ] Push a markdown change and verify `markdown-lint` job runs
- [ ] Push without markdown changes and verify `markdown-lint` job is skipped
- [ ] Verify `markdownlint README.md` passes locally with `.markdownlint.yml` in place

🤖 Generated with [Claude Code](https://claude.ai/code)