### PR TITLE
fix: SUC TLS failure and MicroOS upgrade script exit code

### DIFF
--- a/ansible/roles/addons/tasks/main.yml
+++ b/ansible/roles/addons/tasks/main.yml
@@ -42,6 +42,9 @@
   become: false
   loop: "{{ groups['k3s_workers'] }}"
 
+- name: Import system-upgrade-controller tasks
+  ansible.builtin.import_tasks: system_upgrade_controller.yml
+
 - name: Import cert-manager tasks
   ansible.builtin.import_tasks: cert_manager.yml
 

--- a/ansible/roles/addons/tasks/system_upgrade_controller.yml
+++ b/ansible/roles/addons/tasks/system_upgrade_controller.yml
@@ -1,0 +1,39 @@
+---
+- name: Wait for system-upgrade-controller deployment to exist
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    name: system-upgrade-controller
+    namespace: system-upgrade
+  register: suc_deploy
+  until: suc_deploy.resources is defined and suc_deploy.resources | length > 0
+  retries: 30
+  delay: 10
+  delegate_to: localhost
+  become: false
+
+- name: Patch system-upgrade-controller to mount host CA bundle
+  kubernetes.core.k8s:
+    state: patched
+    kind: Deployment
+    name: system-upgrade-controller
+    namespace: system-upgrade
+    definition:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: system-upgrade-controller
+                env:
+                  - name: SSL_CERT_FILE
+                    value: /etc/ssl/ca-bundle.pem
+                volumeMounts:
+                  - name: host-ca-bundle
+                    mountPath: /etc/ssl/ca-bundle.pem
+                    readOnly: true
+            volumes:
+              - name: host-ca-bundle
+                hostPath:
+                  path: /etc/ssl/ca-bundle.pem
+                  type: File
+  delegate_to: localhost
+  become: false

--- a/tofu/templates/user_data_init_master.yaml.tpl
+++ b/tofu/templates/user_data_init_master.yaml.tpl
@@ -79,7 +79,7 @@ write_files:
           #!/bin/sh
           set -e
           transactional-update --continue cleanup dup
-          [ -f /run/reboot-needed ] && rebootmgrctl reboot now
+          [ -f /run/reboot-needed ] && rebootmgrctl reboot now || true
       ---
       apiVersion: upgrade.cattle.io/v1
       kind: Plan
@@ -115,11 +115,6 @@ write_files:
           matchExpressions:
             - key: node-role.kubernetes.io/worker
               operator: Exists
-        prepare:
-          image: rancher/k3s-upgrade
-          args:
-            - prepare
-            - microos-server
         serviceAccountName: system-upgrade
         secrets:
           - name: microos


### PR DESCRIPTION
## Summary

- Mounts `/etc/ssl/ca-bundle.pem` from MicroOS host into the SUC pod so the controller can verify TLS when resolving the k3s channel URL
- Removes the `prepare` block from the `microos-agent` plan — it was checking kubelet version against `microos`, which can never match
- Adds `|| true` to the reboot check in the upgrade script so it exits 0 when no packages were updated and no reboot is needed

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)